### PR TITLE
Fix scaler zero-range return

### DIFF
--- a/app.py
+++ b/app.py
@@ -236,7 +236,7 @@ for k in selected_tabs:
 def scaler(series: pd.Series):
     if scale_mode.startswith("표준화"):
         rng = series.max() - series.min()
-        return (series - series.min()) / rng if rng != 0 else 0
+        return (series - series.min()) / rng if rng != 0 else pd.Series(0, index=series.index)
     return series
 
 # ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- handle zero-range cases in `scaler`

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6873760a17448320b9e5019209aa6916