### PR TITLE
Add S&P 500 indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 | M2 통화량       | ECOS `060Y002`                                | 월       |
 | USD/KRW      | ECOS `731Y001` or Investing.com CSV           | 일       |
 | KODEX 200 가격 | Investing.com `069500` CSV                    | 일       |
+| S&P 500 지수 | Yahoo Finance `^GSPC` CSV                    | 일       |
 | KRX 금 현물     | KRX 정보데이터시스템 `MDCMGZN001`                     | 일       |
 | 주택매매·전세가격지수  | 부동산원 R‑ONE `(월) 지역별 매매지수_아파트`                 | 주·월     |
 | 미분양주택        | 국토부 Open API `UnsoldHouseStatus`              | 월       |


### PR DESCRIPTION
## Summary
- include S&P 500 index in tracked indicators list

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_6873760b9c74832086625ad5a72064ef