### PR TITLE
Add US M2 data

### DIFF
--- a/app.py
+++ b/app.py
@@ -91,6 +91,8 @@ for c in df.columns:
 after_cols = df.columns
 if "M2_D" not in after_cols and "M2" in after_cols:
     df["M2_D"] = df["M2"].resample("D").interpolate("linear")
+if "M2_US_D" not in after_cols and "M2_US" in after_cols:
+    df["M2_US_D"] = df["M2_US"].resample("D").interpolate("linear")
 
 # ───────────────────────────────────────────────────────────────
 # 2. 기간 슬라이더 & View DF
@@ -202,6 +204,7 @@ TAB_KEYS = {
     "SP500": "S&P 500",
     "BTC": "Bitcoin",
     "M2": "M2 통화량·YoY",
+    "M2US": "미국 M2 통화량·YoY",
     "USDKRW": "환율",
     "Rate": "금리·10Y",
 }
@@ -332,6 +335,29 @@ for tab in selected_tabs:
                 line=dict(width=2, color=next(color_iter)),
             )
 
+    # M2US
+    elif tab == "M2US" and "M2_US_D" in view:
+        m = view["M2_US_D"].resample("M").last().to_frame("M2US_M")
+        if aux_enabled["M2US"]:
+            m["MA6"] = m.M2US_M.rolling(6).mean()
+            m["MA12"] = m.M2US_M.rolling(12).mean()
+            yoy = (m.M2US_M.pct_change(12) * 100).rename("YoY%")
+            fig.add_bar(
+                x=yoy.index,
+                y=scaler(yoy),
+                name="US M2 YoY% (bar)",
+                opacity=0.45,
+                marker_color=next(color_iter),
+            )
+        for col in m.columns:
+            fig.add_scatter(
+                x=m.index,
+                y=scaler(m[col]),
+                name=f"{col}",
+                mode="lines",
+                line=dict(width=2, color=next(color_iter)),
+            )
+
     # USDKRW
     elif tab == "USDKRW" and "FX" in view:
         fx = view[["FX"]]
@@ -406,6 +432,8 @@ if "Bond10" in view:
     snap_vals["10Y (%)"] = view["Bond10"].iloc[-1]
 if "M2_D" in view:
     snap_vals["M2 월말"] = view["M2_D"].resample("M").last().iloc[-1]
+if "M2_US_D" in view:
+    snap_vals["미국 M2 월말"] = view["M2_US_D"].resample("M").last().iloc[-1]
 
 st.markdown("### 최근 값 Snapshot")
 cols = st.columns(len(snap_vals))

--- a/fetch_data.py
+++ b/fetch_data.py
@@ -9,6 +9,7 @@ fetch_data.py  –  거시·자산 원천 데이터 수집 (v4)
 ✓ Rate     : 한국은행 기준금리 (FRED INTDSRKRM193N, 월 → 일 ffill)
 ✓ Bond10   : 국채 10년 수익률 (FRED IRLTLT01KRM156N, 월 → 일 ffill)
 ✓ M2       : 통화량(월) 101Y003 ▷ 060Y002 ▷ LDT_MA001_A → 일 선형보간(M2_D)
+✓ M2_US    : 미국 M2 Money Stock (FRED M2SL, 월 → 일 선형보간)
 ✓ SP500    : S&P 500 (^GSPC, 일)
 ✓ KODEX200 : 069500.KS (일)
 결과 → data/all_data.csv  (일 빈도, ffill)
@@ -120,6 +121,10 @@ dxy  = fred("DTWEXM");                      dxy.name = "DXY";       save("DXY_ra
 rate   = fred(RATE_FRED_ID, freq="m", start="1964-01-01").rename("Rate");      save("Rate_month", rate)
 bond10 = fred(BOND10_FRED_ID, freq="m", start="2000-01-01").rename("Bond10");  save("Bond10_month", bond10)
 
+# --- 미국 M2 (FRED) ------------------------------------------------------------
+m2_us = fred("M2SL", freq="m", start="2008-01-01").rename("M2_US")
+save("M2_US_month", m2_us)
+
 # --- M2 (순차 폴백) ----------------------------------------------------------
 _m2_candidates = [
     ecos("101Y003", ITEM_CODE1="BBHS00"),
@@ -139,10 +144,11 @@ btc   = fetch_adj_close("BTC-USD", start="2014-01-01").rename("Bitcoin"); save("
 rate_d   = rate.resample("D").ffill()
 bond10_d = bond10.resample("D").ffill()
 m2_d     = m2.resample("D").interpolate("linear").rename("M2_D");          save("M2_daily", m2_d)
+m2_us_d  = m2_us.resample("D").interpolate("linear").rename("M2_US_D");      save("M2_US_daily", m2_us_d)
 
 # ── 3. 통합 & 저장 ─────────────────────────────
 all_df = (
-    pd.concat([fx, gold, dxy, rate_d, m2_d, bond10_d, sp500, kodex, btc], axis=1)
+    pd.concat([fx, gold, dxy, rate_d, m2_d, m2_us_d, bond10_d, sp500, kodex, btc], axis=1)
       .sort_index()
       .ffill()
 )


### PR DESCRIPTION
## Summary
- fetch US M2 money stock from FRED and merge into daily dataset
- support new `M2US` tab with YoY bar overlay in the app
- expose latest US M2 level in snapshot

## Testing
- `python3 -m py_compile fetch_data.py app.py`
- `python3 fetch_data.py` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_68737a50d3b88320b57e5ab8367fda4f