### PR TITLE
Mark implemented indicators and precompute heavy data

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,20 +10,19 @@
 
 추가할 것들.
 
-| 지표           | API · 경로                                      | 업데이트 주기 |
-| ------------ | --------------------------------------------- | ------- |
-| 정책금리·국채금리    | 한국은행 ECOS `StatisticSearch` (722Y001,121Y005) | 월/일     |
-| CPI·근원물가     | 통계청 KOSIS `902Y001`                           | 월       |
-| 실질금리         | 금리‑CPI 연산(Pandas)                             | 월       |
-| M2 통화량       | ECOS `060Y002`                                | 월       |
-| USD/KRW      | ECOS `731Y001` or Investing.com CSV           | 일       |
-| KODEX 200 가격 | Investing.com `069500` CSV                    | 일       |
-| 비트코인 가격   | Yahoo Finance `BTC-USD`                      | 일       |
-| KRX 금 현물     | KRX 정보데이터시스템 `MDCMGZN001`                     | 일       |
-| 주택매매·전세가격지수  | 부동산원 R‑ONE `(월) 지역별 매매지수_아파트`                 | 주·월     |
-| 미분양주택        | 국토부 Open API `UnsoldHouseStatus`              | 월       |
-| 매수(우위)지수     | 부동산원 주간동향 HTML 크롤링                            | 주       |
-
+| 지표 | API 경로 | 업데이트 주기 | 상태 |
+| ---- | -------- | ------------- | ---- |
+| 정책금리·국채금리 | 한국은행 ECOS `StatisticSearch` (722Y001,121Y005) | 월/일 | (완료) |
+| CPI·근원물가 | 통계청 KOSIS `902Y001` | 월 | (예정) |
+| 실질금리 | 금리-CPI 연산(Pandas) | 월 | (예정) |
+| M2 통화량 | ECOS `060Y002` | 월 | (완료) |
+| USD/KRW | ECOS `731Y001` 또는 Investing.com CSV | 일 | (완료) |
+| KODEX 200 가격 | Investing.com `069500` CSV | 일 | (완료) |
+| 비트코인 가격 | Yahoo Finance `BTC-USD` | 일 | (완료) |
+| KRX 금 현물 | KRX 정보데이터시스템 `MDCMGZN001` | 일 | (예정) |
+| 주택매매·전세가격지수 | 부동산원 R-ONE `(월) 지역별 매매지수_아파트` | 주·월 | (예정) |
+| 미분양주택 | 국토부 Open API `UnsoldHouseStatus` | 월 | (예정) |
+| 매수(우위)지수 | 부동산원 주간동향 HTML 크롤링 | 주 | (예정) |
 ## 코드베이스 구조
 이 저장소는 Streamlit 대시보드와 데이터를 수집하는 스크립트로 구성되어 있습니다.
 

--- a/app.py
+++ b/app.py
@@ -70,9 +70,9 @@ df: pd.DataFrame = (
     .loc["2008-01-01":]
 )
 
-# Gold 원화 환산
+# Gold 원화 환산 – CSV에 없을 때만 계산
 a0_cols = df.columns
-if {"Gold", "FX"}.issubset(a0_cols):
+if "Gold_KRWg" not in a0_cols and {"Gold", "FX"}.issubset(a0_cols):
     df["Gold_KRWg"] = df["Gold"] * df["FX"] / 31.1035
 
 # KODEX 200 컬럼 정규화
@@ -160,7 +160,11 @@ if "M2_D" in view:
 else:
     s_m2 = pd.Series(dtype=float)
 
-if {"Rate", "Bond10"}.issubset(view.columns):
+if "Spread5D" in view.columns:
+    spread = view["Spread5D"]
+    spread_score = spread.apply(lambda x: 1 if x > 0.5 else -1 if x < 0 else 0)
+    macro = macro.add(spread_score, fill_value=0)
+elif {"Rate", "Bond10"}.issubset(view.columns):
     spread = (view["Bond10"] - view["Rate"]).rolling(5).mean()
     spread_score = spread.apply(lambda x: 1 if x > 0.5 else -1 if x < 0 else 0)
     macro = macro.add(spread_score, fill_value=0)

--- a/fetch_data.py
+++ b/fetch_data.py
@@ -115,6 +115,10 @@ gold = pd.read_csv(
 gold = gold[gold.Close != "-"][["Date", "Close"]].set_index("Date").astype(float).squeeze()
 gold.index = pd.to_datetime(gold.index);    gold.name = "Gold";     save("Gold_raw", gold)
 
+# Gold 원화 환산 (원/그램)
+gold_krwg = (gold * fx / 31.1035).rename("Gold_KRWg")
+save("Gold_KRWg", gold_krwg)
+
 dxy  = fred("DTWEXM");                      dxy.name = "DXY";       save("DXY_raw", dxy)
 
 # --- 기준금리 & 국채 10Y (FRED) ------------------------------------------------
@@ -146,9 +150,29 @@ bond10_d = bond10.resample("D").ffill()
 m2_d     = m2.resample("D").interpolate("linear").rename("M2_D");          save("M2_daily", m2_d)
 m2_us_d  = m2_us.resample("D").interpolate("linear").rename("M2_US_D");      save("M2_US_daily", m2_us_d)
 
+# 금리 스프레드(10Y - 정책금리) 5일 평균
+spread5d = (bond10_d - rate_d).rolling(5).mean().rename("Spread5D")
+save("Spread5D", spread5d)
+
 # ── 3. 통합 & 저장 ─────────────────────────────
 all_df = (
-    pd.concat([fx, gold, dxy, rate_d, m2_d, m2_us_d, bond10_d, sp500, kodex, btc], axis=1)
+    pd.concat(
+        [
+            fx,
+            gold,
+            gold_krwg,
+            dxy,
+            rate_d,
+            bond10_d,
+            spread5d,
+            m2_d,
+            m2_us_d,
+            sp500,
+            kodex,
+            btc,
+        ],
+        axis=1,
+    )
       .sort_index()
       .ffill()
 )


### PR DESCRIPTION
## Summary
- indicate which data sources are implemented in README
- precompute additional metrics such as gold price in KRW and yield spread when fetching data
- read precomputed gold price if available and use stored yield spread in the app

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873808d8a6083208b3a8a25bf363e13