### PR TITLE
Add CPI and real rate data

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@
 | 지표 | API 경로 | 업데이트 주기 | 상태 |
 | ---- | -------- | ------------- | ---- |
 | 정책금리·국채금리 | 한국은행 ECOS `StatisticSearch` (722Y001,121Y005) | 월/일 | (완료) |
-| CPI·근원물가 | 통계청 KOSIS `902Y001` | 월 | (예정) |
-| 실질금리 | 금리-CPI 연산(Pandas) | 월 | (예정) |
+| CPI·근원물가 | FRED `CPIAUCSL`·`CPILFESL` | 월 | (완료) |
+| 실질금리 | 금리-CPI 연산(Pandas) | 월 | (완료) |
 | M2 통화량 | ECOS `060Y002` | 월 | (완료) |
 | USD/KRW | ECOS `731Y001` 또는 Investing.com CSV | 일 | (완료) |
 | KODEX 200 가격 | Investing.com `069500` CSV | 일 | (완료) |

--- a/app.py
+++ b/app.py
@@ -219,6 +219,9 @@ TAB_KEYS = {
     "M2US": "미국 M2 통화량·YoY",
     "USDKRW": "환율",
     "Rate": "금리·10Y",
+    "CPI": "CPI",
+    "CoreCPI": "근원 CPI",
+    "RealRate": "실질 금리",
 }
 
 st.sidebar.markdown("### 🔀 탭 On / Off")
@@ -389,6 +392,58 @@ for tab in selected_tabs:
                 line=dict(width=2, color=next(color_iter)),
             )
 
+    # CPI
+    elif tab == "CPI" and "CPI_D" in view:
+        c = view["CPI_D"].resample("ME").last().to_frame("CPI")
+        if aux_enabled.get("CPI"):
+            yoy = (c.CPI.pct_change(12) * 100).rename("YoY%")
+            fig.add_bar(
+                x=yoy.index,
+                y=scaler(yoy),
+                name="CPI YoY% (bar)",
+                opacity=0.45,
+                marker_color=next(color_iter),
+            )
+        fig.add_scatter(
+            x=c.index,
+            y=scaler(c["CPI"]),
+            name="CPI",
+            mode="lines",
+            line=dict(width=2, color=next(color_iter)),
+        )
+
+    # Core CPI
+    elif tab == "CoreCPI" and "CoreCPI_D" in view:
+        c = view["CoreCPI_D"].resample("ME").last().to_frame("CoreCPI")
+        if aux_enabled.get("CoreCPI"):
+            yoy = (c.CoreCPI.pct_change(12) * 100).rename("YoY%")
+            fig.add_bar(
+                x=yoy.index,
+                y=scaler(yoy),
+                name="Core CPI YoY% (bar)",
+                opacity=0.45,
+                marker_color=next(color_iter),
+            )
+        fig.add_scatter(
+            x=c.index,
+            y=scaler(c["CoreCPI"]),
+            name="Core CPI",
+            mode="lines",
+            line=dict(width=2, color=next(color_iter)),
+        )
+
+    # Real Rate
+    elif tab == "RealRate" and "RealRate_D" in view:
+        r = view["RealRate_D"].resample("ME").last().to_frame("RealRate")
+        for col in r.columns:
+            fig.add_scatter(
+                x=r.index,
+                y=scaler(r[col]),
+                name="Real Rate",
+                mode="lines",
+                line=dict(width=2, color=next(color_iter)),
+            )
+
     # Rate & Bond10
     elif tab == "Rate" and {"Rate", "Bond10"}.issubset(view.columns):
         r = view[["Rate", "Bond10"]].copy()
@@ -450,6 +505,12 @@ if "M2_D" in view:
     snap_vals["M2 월말"] = view["M2_D"].resample("ME").last().iloc[-1]
 if "M2_US_D" in view:
     snap_vals["미국 M2 월말"] = view["M2_US_D"].resample("ME").last().iloc[-1]
+if "CPI_D" in view:
+    snap_vals["CPI"] = view["CPI_D"].resample("ME").last().iloc[-1]
+if "CoreCPI_D" in view:
+    snap_vals["Core CPI"] = view["CoreCPI_D"].resample("ME").last().iloc[-1]
+if "RealRate_D" in view:
+    snap_vals["Real Rate"] = view["RealRate_D"].resample("ME").last().iloc[-1]
 
 st.markdown("### 최근 값 Snapshot")
 
@@ -463,6 +524,9 @@ snap_units = {
     "10Y (%)": "%",
     "M2 월말": "₩",
     "미국 M2 월말": "$",
+    "CPI": "%",
+    "Core CPI": "%",
+    "Real Rate": "%",
 }
 
 snap_tbl = pd.DataFrame(

--- a/fetch_data.py
+++ b/fetch_data.py
@@ -37,6 +37,8 @@ DIR = Path("data"); DIR.mkdir(exist_ok=True)
 # FRED 시리즈 ID 상수화
 RATE_FRED_ID   = "INTDSRKRM193N"    # Bank of Korea Base Rate (monthly)
 BOND10_FRED_ID = "IRLTLT01KRM156N"  # 10‑Year Government Bond Yield (monthly)
+CPI_FRED_ID    = "CPIAUCSL"          # CPI All Items (monthly)
+CORECPI_FRED_ID = "CPILFESL"         # Core CPI (monthly)
 
 # ── 공통 유틸 ───────────────────────────────────
 
@@ -125,6 +127,17 @@ dxy  = fred("DTWEXM");                      dxy.name = "DXY";       save("DXY_ra
 rate   = fred(RATE_FRED_ID, freq="m", start="1964-01-01").rename("Rate");      save("Rate_month", rate)
 bond10 = fred(BOND10_FRED_ID, freq="m", start="2000-01-01").rename("Bond10");  save("Bond10_month", bond10)
 
+# --- 물가 (FRED) --------------------------------------------------------------
+cpi = fred(CPI_FRED_ID, freq="m", start="2000-01-01").rename("CPI")
+save("CPI_month", cpi)
+core_cpi = fred(CORECPI_FRED_ID, freq="m", start="2000-01-01").rename("CoreCPI")
+save("CoreCPI_month", core_cpi)
+
+# Real Rate = 정책금리 - CPI YoY
+cpi_yoy = cpi.pct_change(12) * 100
+real_rate = (rate - cpi_yoy).rename("RealRate")
+save("RealRate_month", real_rate)
+
 # --- 미국 M2 (FRED) ------------------------------------------------------------
 m2_us = fred("M2SL", freq="m", start="2008-01-01").rename("M2_US")
 save("M2_US_month", m2_us)
@@ -149,6 +162,9 @@ rate_d   = rate.resample("D").ffill()
 bond10_d = bond10.resample("D").ffill()
 m2_d     = m2.resample("D").interpolate("linear").rename("M2_D");          save("M2_daily", m2_d)
 m2_us_d  = m2_us.resample("D").interpolate("linear").rename("M2_US_D");      save("M2_US_daily", m2_us_d)
+cpi_d     = cpi.resample("D").ffill().rename("CPI_D");            save("CPI_daily", cpi_d)
+core_cpi_d = core_cpi.resample("D").ffill().rename("CoreCPI_D");  save("CoreCPI_daily", core_cpi_d)
+real_rate_d = real_rate.resample("D").ffill().rename("RealRate_D"); save("RealRate_daily", real_rate_d)
 
 # 금리 스프레드(10Y - 정책금리) 5일 평균
 spread5d = (bond10_d - rate_d).rolling(5).mean().rename("Spread5D")
@@ -167,6 +183,9 @@ all_df = (
             spread5d,
             m2_d,
             m2_us_d,
+            cpi_d,
+            core_cpi_d,
+            real_rate_d,
             sp500,
             kodex,
             btc,


### PR DESCRIPTION
## Summary
- fetch CPI and Core CPI series from FRED
- compute real interest rate from CPI YoY
- convert to daily data and include in combined dataset
- visualize CPI, Core CPI and Real Rate in dashboard
- show latest CPI metrics in snapshot

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687386e7ecf0832096aa1f596b3fc0d8