### PR TITLE
Fix CPI column detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@
 | 지표 | API 경로 | 업데이트 주기 | 상태 |
 | ---- | -------- | ------------- | ---- |
 | 정책금리·국채금리 | 한국은행 ECOS `StatisticSearch` (722Y001,121Y005) | 월/일 | (완료) |
-| CPI·근원물가 | 통계청 KOSIS `902Y001` | 월 | (예정) |
-| 실질금리 | 금리-CPI 연산(Pandas) | 월 | (예정) |
+| CPI·근원물가 | FRED `CPIAUCSL`·`CPILFESL` | 월 | (완료) |
+| 실질금리 | 금리-CPI 연산(Pandas) | 월 | (완료) |
 | M2 통화량 | ECOS `060Y002` | 월 | (완료) |
 | USD/KRW | ECOS `731Y001` 또는 Investing.com CSV | 일 | (완료) |
 | KODEX 200 가격 | Investing.com `069500` CSV | 일 | (완료) |

--- a/app.py
+++ b/app.py
@@ -67,11 +67,7 @@ if not DATA_FP.exists():
 def load_df(path: Path) -> pd.DataFrame:
     """CSV 로드 및 컬럼 정리 과정을 캐시합니다."""
 
-    df = (
-        pd.read_csv(path, index_col=0, parse_dates=True)
-        .ffill()
-        .loc["2008-01-01":]
-    )
+    df = pd.read_csv(path, index_col=0, parse_dates=True).ffill().loc["2008-01-01":]
 
     # Gold 원화 환산 – CSV에 없을 때만 계산
     a0_cols = df.columns
@@ -97,6 +93,34 @@ def load_df(path: Path) -> pd.DataFrame:
     if "M2_US_D" not in after_cols and "M2_US" in after_cols:
         df["M2_US_D"] = df["M2_US"].resample("D").interpolate("linear")
 
+    # CPI 및 Core CPI 컬럼 정규화
+    for c in list(df.columns):
+        uc = c.upper()
+        if uc.startswith("CPIAUCSL"):
+            df.rename(
+                columns={c: "CPI" if not uc.endswith("_D") else "CPI_D"}, inplace=True
+            )
+        elif uc.startswith("CPILFESL"):
+            df.rename(
+                columns={c: "CoreCPI" if not uc.endswith("_D") else "CoreCPI_D"},
+                inplace=True,
+            )
+
+    # CPI 일별 보간
+    after_cols = df.columns
+    if "CPI_D" not in after_cols and "CPI" in after_cols:
+        df["CPI_D"] = df["CPI"].resample("D").ffill()
+    if "CoreCPI_D" not in after_cols and "CoreCPI" in after_cols:
+        df["CoreCPI_D"] = df["CoreCPI"].resample("D").ffill()
+
+    # Real Rate 계산 (정책금리 - CPI YoY)
+    if "RealRate_D" not in after_cols and {"Rate", "CPI_D"}.issubset(after_cols):
+        cpi_yoy = df["CPI_D"].resample("ME").last().pct_change(12) * 100
+        rr = (df["Rate"].resample("ME").last() - cpi_yoy).reindex(
+            df.index, method="ffill"
+        )
+        df["RealRate_D"] = rr
+
     return df
 
 
@@ -113,7 +137,9 @@ with st.sidebar:
     mid_date = df.index.max().date() - relativedelta(years=3)
 
     d0, d1, d2 = start_date, end_date, mid_date
-    _date = st.slider("기간", d0, d1, (d2, d1), format="YYYY-MM-DD", key="date_slider_3y")
+    _date = st.slider(
+        "기간", d0, d1, (d2, d1), format="YYYY-MM-DD", key="date_slider_3y"
+    )
     d_from, d_to = _date
 
 view = df.loc[pd.to_datetime(d_from) : pd.to_datetime(d_to)].copy()
@@ -127,11 +153,13 @@ sig_dt = view.index[-1].strftime("%Y-%m-%d")
 # 3. Trend·Macro 점수
 # ----------------------------------------------------------------
 
+
 def trend_score(series, short: int = 20, long: int = 50):
     ma_s, ma_l = series.rolling(short).mean(), series.rolling(long).mean()
     cross = np.sign(ma_s - ma_l)
     mom_1m = np.sign(series.pct_change(21))
     return (cross + mom_1m).clip(-2, 2)
+
 
 trend = {}
 if "Gold_KRWg" in view:
@@ -182,15 +210,22 @@ macro = macro.clip(-3, 3)
 # ───────────────────────────────────────────────────────────────
 # 4. 색상·유틸 및 월별 세로선 함수
 # ----------------------------------------------------------------
-COLORS = px.colors.qualitative.Plotly + px.colors.qualitative.Set2 + px.colors.qualitative.Set3
+COLORS = (
+    px.colors.qualitative.Plotly
+    + px.colors.qualitative.Set2
+    + px.colors.qualitative.Set3
+)
 SIG_COL_LINE = {2: "#16a085", 1: "#2ecc71", -1: "#f39c12", -2: "#e74c3c"}
 
 # Signal 라인을 완전히 비활성화 (빈 리스트 반환)
 
+
 def vlines(*args, **kwargs):
     return []
 
+
 # 매월 1일에 얇은 세로선 추가 – 한 번만 실행
+
 
 def add_monthly_guides(fig: go.Figure, start: pd.Timestamp, end: pd.Timestamp):
     """주어진 구간의 매월 1일에 세로선을 한 번씩 추가합니다."""
@@ -207,6 +242,7 @@ def add_monthly_guides(fig: go.Figure, start: pd.Timestamp, end: pd.Timestamp):
             layer="below",
         )
 
+
 # ───────────────────────────────────────────────────────────────
 # 5. Sidebar – 탭 토글 & 스케일 모드 + 보조 지표 토글
 # ----------------------------------------------------------------
@@ -219,6 +255,9 @@ TAB_KEYS = {
     "M2US": "미국 M2 통화량·YoY",
     "USDKRW": "환율",
     "Rate": "금리·10Y",
+    "CPI": "CPI",
+    "CoreCPI": "근원 CPI",
+    "RealRate": "실질 금리",
 }
 
 st.sidebar.markdown("### 🔀 탭 On / Off")
@@ -245,21 +284,25 @@ AUX_DEFAULTS = {k: False for k in TAB_KEYS}
 
 aux_enabled = {}
 for k in selected_tabs:
-    aux_enabled[k] = st.sidebar.toggle(f"{TAB_KEYS[k]} 보조 지표", value=AUX_DEFAULTS[k], key=f"aux_{k}")
+    aux_enabled[k] = st.sidebar.toggle(
+        f"{TAB_KEYS[k]} 보조 지표", value=AUX_DEFAULTS[k], key=f"aux_{k}"
+    )
 
 # ───────────────────────────────────────────────────────────────
 # 6. 스케일 함수
 # ----------------------------------------------------------------
 
+
 def scaler(series: pd.Series):
     if scale_mode.startswith("표준화"):
         rng = series.max() - series.min()
-        
+
         if rng != 0:
             return (series - series.min()) / rng
         return pd.Series(0, index=series.index)
-      
+
     return series
+
 
 # ───────────────────────────────────────────────────────────────
 # 7. Figure – 선택 탭 Trace 합성
@@ -389,6 +432,58 @@ for tab in selected_tabs:
                 line=dict(width=2, color=next(color_iter)),
             )
 
+    # CPI
+    elif tab == "CPI" and "CPI_D" in view:
+        c = view["CPI_D"].resample("ME").last().to_frame("CPI")
+        if aux_enabled.get("CPI"):
+            yoy = (c.CPI.pct_change(12) * 100).rename("YoY%")
+            fig.add_bar(
+                x=yoy.index,
+                y=scaler(yoy),
+                name="CPI YoY% (bar)",
+                opacity=0.45,
+                marker_color=next(color_iter),
+            )
+        fig.add_scatter(
+            x=c.index,
+            y=scaler(c["CPI"]),
+            name="CPI",
+            mode="lines",
+            line=dict(width=2, color=next(color_iter)),
+        )
+
+    # Core CPI
+    elif tab == "CoreCPI" and "CoreCPI_D" in view:
+        c = view["CoreCPI_D"].resample("ME").last().to_frame("CoreCPI")
+        if aux_enabled.get("CoreCPI"):
+            yoy = (c.CoreCPI.pct_change(12) * 100).rename("YoY%")
+            fig.add_bar(
+                x=yoy.index,
+                y=scaler(yoy),
+                name="Core CPI YoY% (bar)",
+                opacity=0.45,
+                marker_color=next(color_iter),
+            )
+        fig.add_scatter(
+            x=c.index,
+            y=scaler(c["CoreCPI"]),
+            name="Core CPI",
+            mode="lines",
+            line=dict(width=2, color=next(color_iter)),
+        )
+
+    # Real Rate
+    elif tab == "RealRate" and "RealRate_D" in view:
+        r = view["RealRate_D"].resample("ME").last().to_frame("RealRate")
+        for col in r.columns:
+            fig.add_scatter(
+                x=r.index,
+                y=scaler(r[col]),
+                name="Real Rate",
+                mode="lines",
+                line=dict(width=2, color=next(color_iter)),
+            )
+
     # Rate & Bond10
     elif tab == "Rate" and {"Rate", "Bond10"}.issubset(view.columns):
         r = view[["Rate", "Bond10"]].copy()
@@ -403,7 +498,11 @@ for tab in selected_tabs:
                 y=scaler(r[col]),
                 name=col,
                 mode="lines",
-                line=dict(width=2, color=next(color_iter), dash="dot" if "MA" in col else "solid"),
+                line=dict(
+                    width=2,
+                    color=next(color_iter),
+                    dash="dot" if "MA" in col else "solid",
+                ),
             )
 
 # 월별 세로 가이드라인 추가
@@ -450,6 +549,12 @@ if "M2_D" in view:
     snap_vals["M2 월말"] = view["M2_D"].resample("ME").last().iloc[-1]
 if "M2_US_D" in view:
     snap_vals["미국 M2 월말"] = view["M2_US_D"].resample("ME").last().iloc[-1]
+if "CPI_D" in view:
+    snap_vals["CPI"] = view["CPI_D"].resample("ME").last().iloc[-1]
+if "CoreCPI_D" in view:
+    snap_vals["Core CPI"] = view["CoreCPI_D"].resample("ME").last().iloc[-1]
+if "RealRate_D" in view:
+    snap_vals["Real Rate"] = view["RealRate_D"].resample("ME").last().iloc[-1]
 
 st.markdown("### 최근 값 Snapshot")
 
@@ -463,6 +568,9 @@ snap_units = {
     "10Y (%)": "%",
     "M2 월말": "₩",
     "미국 M2 월말": "$",
+    "CPI": "%",
+    "Core CPI": "%",
+    "Real Rate": "%",
 }
 
 snap_tbl = pd.DataFrame(
@@ -483,8 +591,10 @@ with st.expander("🔔 통합 자산 시그널", expanded=False):
         final_scores[asset] = int((ts + macro).clip(-3, 3).iloc[-1])
 
     if "RTMS" in view:
-        realty_trend = view["RTMS"].pct_change(3).apply(
-            lambda x: 2 if x > 0.03 else 1 if x > 0 else -1 if x > -0.03 else -2
+        realty_trend = (
+            view["RTMS"]
+            .pct_change(3)
+            .apply(lambda x: 2 if x > 0.03 else 1 if x > 0 else -1 if x > -0.03 else -2)
         )
         final_scores["Realty"] = int((realty_trend + macro).clip(-3, 3).iloc[-1])
 
@@ -502,4 +612,6 @@ with st.expander("🔔 통합 자산 시그널", expanded=False):
     else:
         st.info("시그널을 계산할 데이터가 부족합니다.")
 
-st.caption("Data: FRED · Stooq · ECOS · Yahoo Finance — Signals = Macro(M2 + Spread) × Trend")
+st.caption(
+    "Data: FRED · Stooq · ECOS · Yahoo Finance — Signals = Macro(M2 + Spread) × Trend"
+)

--- a/fetch_data.py
+++ b/fetch_data.py
@@ -37,6 +37,8 @@ DIR = Path("data"); DIR.mkdir(exist_ok=True)
 # FRED 시리즈 ID 상수화
 RATE_FRED_ID   = "INTDSRKRM193N"    # Bank of Korea Base Rate (monthly)
 BOND10_FRED_ID = "IRLTLT01KRM156N"  # 10‑Year Government Bond Yield (monthly)
+CPI_FRED_ID    = "CPIAUCSL"          # CPI All Items (monthly)
+CORECPI_FRED_ID = "CPILFESL"         # Core CPI (monthly)
 
 # ── 공통 유틸 ───────────────────────────────────
 
@@ -125,6 +127,17 @@ dxy  = fred("DTWEXM");                      dxy.name = "DXY";       save("DXY_ra
 rate   = fred(RATE_FRED_ID, freq="m", start="1964-01-01").rename("Rate");      save("Rate_month", rate)
 bond10 = fred(BOND10_FRED_ID, freq="m", start="2000-01-01").rename("Bond10");  save("Bond10_month", bond10)
 
+# --- 물가 (FRED) --------------------------------------------------------------
+cpi = fred(CPI_FRED_ID, freq="m", start="2000-01-01").rename("CPI")
+save("CPI_month", cpi)
+core_cpi = fred(CORECPI_FRED_ID, freq="m", start="2000-01-01").rename("CoreCPI")
+save("CoreCPI_month", core_cpi)
+
+# Real Rate = 정책금리 - CPI YoY
+cpi_yoy = cpi.pct_change(12) * 100
+real_rate = (rate - cpi_yoy).rename("RealRate")
+save("RealRate_month", real_rate)
+
 # --- 미국 M2 (FRED) ------------------------------------------------------------
 m2_us = fred("M2SL", freq="m", start="2008-01-01").rename("M2_US")
 save("M2_US_month", m2_us)
@@ -149,6 +162,9 @@ rate_d   = rate.resample("D").ffill()
 bond10_d = bond10.resample("D").ffill()
 m2_d     = m2.resample("D").interpolate("linear").rename("M2_D");          save("M2_daily", m2_d)
 m2_us_d  = m2_us.resample("D").interpolate("linear").rename("M2_US_D");      save("M2_US_daily", m2_us_d)
+cpi_d     = cpi.resample("D").ffill().rename("CPI_D");            save("CPI_daily", cpi_d)
+core_cpi_d = core_cpi.resample("D").ffill().rename("CoreCPI_D");  save("CoreCPI_daily", core_cpi_d)
+real_rate_d = real_rate.resample("D").ffill().rename("RealRate_D"); save("RealRate_daily", real_rate_d)
 
 # 금리 스프레드(10Y - 정책금리) 5일 평균
 spread5d = (bond10_d - rate_d).rolling(5).mean().rename("Spread5D")
@@ -167,6 +183,9 @@ all_df = (
             spread5d,
             m2_d,
             m2_us_d,
+            cpi_d,
+            core_cpi_d,
+            real_rate_d,
             sp500,
             kodex,
             btc,


### PR DESCRIPTION
## Summary
- normalize CPI and core CPI column names on data load
- backfill daily CPI and real rate values if missing

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687386e7ecf0832096aa1f596b3fc0d8