### PR TITLE
Fix Streamlit popover args

### DIFF
--- a/app.py
+++ b/app.py
@@ -264,7 +264,9 @@ for key, label in TAB_KEYS.items():
     with col_t:
         val = st.toggle(label, value=default_on, key=f"tab_{key}")
     with col_p:
-        with st.popover("❔", key=f"pop_{key}"):
+        # st.popover does not accept a key argument in recent Streamlit
+        # versions, so we omit it to avoid a TypeError.
+        with st.popover("❔"):
             st.markdown(REL_MD.get(key, ""))
     if val:
         selected_tabs.append(key)


### PR DESCRIPTION
## Summary
- avoid passing unsupported `key` argument to `st.popover`

## Testing
- `pytest -q`
- `streamlit run app.py` *(fails to detect external IP but starts without TypeError)*

------
https://chatgpt.com/codex/tasks/task_e_687397a0b38083208b7280f1677aca53