### PR TITLE
Fix M2 snapshot unit

### DIFF
--- a/app.py
+++ b/app.py
@@ -616,14 +616,19 @@ snap_units = {
     "연준금리 (%)": "%",
     "미국10Y (%)": "%",
     "국내 M2 월말": "₩",
-    "미국 M2 월말": "$",
+    "미국 M2 월말": " B",
     "CPI": "",
     "Real Rate": "%",
 }
 
+def _fmt(val: float, unit: str) -> str:
+    if unit == "₩":
+        return f"{val:,.0f}{unit}"
+    return f"{val:,.2f}{unit}"
+
 snap_tbl = pd.DataFrame(
     [
-        {"항목": label, "값": f"{val:,.2f}{snap_units.get(label, '')}"}
+        {"항목": label, "값": _fmt(val, snap_units.get(label, ""))}
         for label, val in snap_vals.items()
     ]
 )


### PR DESCRIPTION
## Summary
- show US M2 in billions rather than as a dollar value
- add formatting helper to display Korean won values as integers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873bba973448320b871b0537f0f97d5