### PR TITLE
Turn on Real Rate tab by default

### DIFF
--- a/app.py
+++ b/app.py
@@ -328,7 +328,7 @@ for t, cols in TAB_REQUIRES.items():
 for key, label in TAB_KEYS.items():
     if key not in available_tabs:
         continue
-    default_on = key in {"Gold", "KODEX"}
+    default_on = key in {"Gold", "KODEX", "RealRate"}
     col_t, col_p = st.sidebar.columns([6, 1])
     with col_t:
         val = st.toggle(label, value=default_on, key=f"tab_{key}")


### PR DESCRIPTION
## Summary
- update default tab toggles to include real rate

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687660e7c61083209ca93b2575af19ab